### PR TITLE
Modified Get-ADOFeedURL function to handle project-scoped feeds. Added pattern validation to Feed parameter.

### DIFF
--- a/src/PowershellModule/Functions/Private/Helpers.ps1
+++ b/src/PowershellModule/Functions/Private/Helpers.ps1
@@ -1,18 +1,19 @@
 <#
 .SYNOPSIS
-    Build a nuget Feed url from the account/feed info
+    Build a nuget Feed url from the Account/Feed info. Account may consist of just Organization or Organization/Project.
+.PARAMETER feed
+    The feed Account and value. Expected format as "Organization/Feed" or "Organization/Project/Feed".
 #>
 function Get-ADOFeedURL {
     [CmdletBinding()]
     [OutputType('System.String')]
     Param(
-        [Parameter(Mandatory=$true, Position=0)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [string] $Feed
     )
 
-    $Components = $Feed.Split('/')
-    $Account = $Components[0]
-    $FeedName = $Components[1]
+    $Account = $Feed.Substring(0, $Feed.LastIndexOf('/'))
+    $FeedName = $Feed.Substring($Feed.LastIndexOf('/') + 1)
 
     "https://pkgs.dev.azure.com/$Account/_packaging/$FeedName/nuget/v2/"
 }
@@ -26,7 +27,7 @@ function Get-ADOFeedCredential {
     [OutputType('System.Management.Automation.PSCredential')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
     Param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string] $FeedUrl,
 
         [Parameter()]
@@ -42,12 +43,14 @@ function Get-ADOFeedCredential {
         # See: https://github.com/OneGet/oneget/issues/460
         # This forces CredentialProvider to use the provided AccessToken
         $env:VSS_NUGET_ACCESSTOKEN = $AccessToken
-        $env:VSS_NUGET_URI_PREFIXES = $FeedUrl -replace "\/$",""
-    } else {
+        $env:VSS_NUGET_URI_PREFIXES = $FeedUrl -replace "\/$", ""
+    }
+    else {
         $Verbosity = ""
         if ($VerbosePreference -match "Silent") {
             $Verbosity = "Silent"
-        } else {
+        }
+        else {
             $Verbosity = "Detailed"
         }
 

--- a/src/PowershellModule/Functions/Public/Install-ADOPSModule.ps1
+++ b/src/PowershellModule/Functions/Public/Install-ADOPSModule.ps1
@@ -10,6 +10,7 @@ function Install-ADOPSModule {
     param(
         [Parameter(Mandatory=$true, Position=0, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNull()]
+        [ValidatePattern("^(?:\w+\/)+\w+$")]
         [string]
         $Feed,
 


### PR DESCRIPTION
Added support for [project-scoped feeds](https://docs.microsoft.com/en-us/azure/devops/artifacts/feeds/project-scoped-feeds?view=azure-devops#project-scoped-vs-organization-scoped-feeds). Module can now hand both org-scoped feeds (`Organization/Feed`) and project-scoped feeds (`Organization/Project/Feed`). Additionally, added pattern validation ([regex example](https://regex101.com/r/7ptL2y/1)) for the feed.

Before:
```
PS > Get-ADOFeedURL "Organization/Feed"        

https://pkgs.dev.azure.com/Organization/_packaging/Feed/nuget/v2/
PS > Get-ADOFeedURL "Organization/Project/Feed"

https://pkgs.dev.azure.com/Organization/_packaging/Project/nuget/v2/
```
After:
```
PS > Get-ADOFeedURL "Organization/Feed"                                 

https://pkgs.dev.azure.com/Organization/_packaging/Feed/nuget/v2/
PS > Get-ADOFeedURL "Organization/Project/Feed"

https://pkgs.dev.azure.com/Organization/Project/_packaging/Feed/nuget/v2/
```